### PR TITLE
Add files via upload

### DIFF
--- a/marine_vending.dm
+++ b/marine_vending.dm
@@ -1,0 +1,794 @@
+///******MARINE VENDOR******///
+
+/obj/machinery/vending/marine
+	name = "\improper Automated Weapons Rack"
+	desc = "A automated weapon rack hooked up to a colossal storage of standard-issue weapons."
+	icon_state = "marinearmory"
+	icon_vend = "marinearmory-vend"
+	icon_deny = "marinearmory"
+	wrenchable = FALSE
+	tokensupport = TOKEN_MARINE
+
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	products = list(
+		/obj/item/weapon/gun/pistol/standard_pistol = 25,
+		/obj/item/ammo_magazine/pistol/standard_pistol = 30,
+		/obj/item/weapon/gun/pistol/standard_heavypistol = 10,
+		/obj/item/ammo_magazine/pistol/standard_heavypistol = 25,
+		/obj/item/weapon/gun/revolver/standard_revolver = 15,
+		/obj/item/ammo_magazine/revolver/standard_revolver = 25,
+		/obj/item/weapon/gun/smg/standard_machinepistol = 20,
+		/obj/item/ammo_magazine/smg/standard_machinepistol = 30,
+		/obj/item/weapon/gun/pistol/standard_pocketpistol = 25,
+		/obj/item/ammo_magazine/pistol/standard_pocketpistol = 50,
+		/obj/item/weapon/gun/smg/standard_smg = 20,
+		/obj/item/ammo_magazine/smg/standard_smg = 30,
+		/obj/item/weapon/gun/rifle/standard_carbine = 25,
+		/obj/item/ammo_magazine/rifle/standard_carbine = 25,
+		/obj/item/weapon/gun/rifle/standard_assaultrifle = 25,
+		/obj/item/ammo_magazine/rifle/standard_assaultrifle = 25,
+		/obj/item/weapon/gun/rifle/standard_lmg = 15,
+		/obj/item/ammo_magazine/standard_lmg = 30,
+		/obj/item/weapon/gun/rifle/standard_gpmg = 15,
+		/obj/item/ammo_magazine/standard_gpmg = 30,
+		/obj/item/weapon/gun/rifle/standard_dmr = 10,
+		/obj/item/ammo_magazine/rifle/standard_dmr = 25,
+		/obj/item/weapon/gun/rifle/standard_br = 10,
+		/obj/item/ammo_magazine/rifle/standard_br = 25,
+		/obj/item/weapon/gun/rifle/chambered = 20,
+		/obj/item/ammo_magazine/rifle/chamberedrifle = 20,
+		/obj/item/weapon/gun/energy/lasgun/lasrifle = 10,
+		/obj/item/cell/lasgun/lasrifle = 20,
+		/obj/item/weapon/gun/shotgun/pump/t35 = 10,
+		/obj/item/weapon/gun/shotgun/combat/standardmarine = 10,
+		/obj/item/ammo_magazine/shotgun = 10,
+		/obj/item/ammo_magazine/shotgun/buckshot = 10,
+		/obj/item/ammo_magazine/shotgun/flechette = 10,
+		/obj/item/weapon/gun/rifle/standard_autoshotgun = 10,
+		/obj/item/ammo_magazine/rifle/tx15_slug = 25,
+		/obj/item/ammo_magazine/rifle/tx15_flechette = 25,
+		/obj/item/weapon/gun/launcher/m92/standardmarine = 10,
+		/obj/item/weapon/gun/launcher/m81 = 15,
+		/obj/item/explosive/grenade/frag = 30,
+		/obj/item/attachable/bayonetknife = 20,
+		/obj/item/weapon/throwing_knife = 5,
+		/obj/item/storage/box/m94 = 5,
+		/obj/item/attachable/flashlight = 10,
+		/obj/item/explosive/grenade/mirage = 5,
+	)
+	prices = list()
+
+/obj/machinery/vending/marine/select_gamemode_equipment(gamemode)
+	var/products2[]
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		products2 = list(/obj/item/clothing/mask/rebreather/scarf = 10, /obj/item/clothing/mask/rebreather = 10)
+	build_inventory(products2)
+
+/obj/machinery/vending/marine/Initialize()
+	. = ..()
+	GLOB.marine_vendors.Add(src)
+
+/obj/machinery/vending/marine/Destroy()
+	. = ..()
+	GLOB.marine_vendors.Remove(src)
+
+//What do grenade do against candy machine?
+/obj/machinery/vending/marine/ex_act(severity)
+	return
+
+/obj/machinery/vending/marine/cargo_supply
+	name = "\improper Operational Supplies Vendor"
+	desc = "A large vendor for dispensing specialty and bulk supplies. Restricted to cargo personnel only."
+	icon_state = "synth"
+	icon_vend = "synth-vend"
+	icon_deny = "synth-deny"
+	wrenchable = FALSE
+	req_one_access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_LOGISTICS)
+	products = list(
+		/obj/item/storage/box/ammo = 30,
+		/obj/item/storage/box/nade_box = 2,
+		/obj/item/storage/box/nade_box/HIDP = 2,
+		/obj/item/storage/box/nade_box/M15 = 2,
+		/obj/item/storage/box/nade_box/plasma_drain_gas = 1,
+		/obj/item/ammo_magazine/rifle/autosniper = 3,
+		/obj/item/ammo_magazine/rifle/m4ra = 3,
+		/obj/item/ammo_magazine/rocket/sadar = 3,
+		/obj/item/ammo_magazine/minigun = 2,
+		/obj/item/bodybag/tarp = 2,
+		/obj/item/explosive/plastique = 2,
+		/obj/item/radio/headset/mainship/marine/alpha = 20,
+		/obj/item/radio/headset/mainship/marine/bravo = 20,
+		/obj/item/radio/headset/mainship/marine/charlie = 20,
+		/obj/item/radio/headset/mainship/marine/delta = 20,
+	)
+
+/obj/machinery/vending/marine/cargo_guns
+	name = "\improper Automated Armaments Vendor"
+	desc = "A automated rack hooked up to a small supply of various firearms and explosives."
+	wrenchable = FALSE
+	products = list(
+		/obj/item/weapon/gun/pistol/standard_pistol = 10,
+		/obj/item/weapon/gun/revolver/standard_revolver = 10,
+		/obj/item/weapon/gun/pistol/standard_heavypistol = 10,
+		/obj/item/weapon/gun/pistol/vp70 = 10,
+		/obj/item/weapon/gun/smg/ppsh = 5,
+		/obj/item/weapon/gun/smg/standard_smg = 10,
+		/obj/item/weapon/gun/smg/standard_machinepistol = 10,
+		/obj/item/weapon/gun/rifle/standard_carbine = 10,
+		/obj/item/weapon/gun/rifle/standard_assaultrifle = 10,
+		/obj/item/weapon/gun/rifle/standard_lmg = 10,
+		/obj/item/weapon/gun/rifle/standard_gpmg = 10,
+		/obj/item/weapon/gun/rifle/standard_dmr = 10,
+		/obj/item/weapon/gun/rifle/standard_br = 10,
+		/obj/item/weapon/gun/energy/lasgun/lasrifle = 10,
+		/obj/item/weapon/gun/rifle/chambered = 10,
+		/obj/item/weapon/gun/shotgun/pump/t35 = 10,
+		/obj/item/weapon/gun/shotgun/combat/standardmarine = 10,
+		/obj/item/weapon/gun/rifle/standard_autoshotgun = 10,
+		/obj/item/weapon/gun/launcher/m92/standardmarine = 10,
+		/obj/item/weapon/gun/launcher/m81 = 15,
+		/obj/item/weapon/gun/pistol/standard_pocketpistol = 20,
+		/obj/item/storage/belt/gun/ts34/full = 5,
+		/obj/item/weapon/gun/shotgun/pump/cmb = 5,
+		/obj/item/weapon/gun/shotgun/pump/bolt = 5,
+		/obj/item/weapon/gun/flamer/marinestandard = 2,
+		/obj/item/explosive/mine = 5,
+		/obj/item/explosive/grenade/frag/m15 = 25,
+		/obj/item/explosive/grenade/incendiary = 25,
+		/obj/item/explosive/grenade/drainbomb = 5,
+		/obj/item/explosive/grenade/cloakbomb = 25,
+		/obj/item/storage/box/m94 = 30,
+		/obj/item/storage/box/recoilless_system = 1,
+		/obj/item/weapon/shield/riot/marine = 3,
+		/obj/item/weapon/gun/shotgun/pump/lever/mbx900 = 1,
+	)
+
+	premium = list()
+	contraband = list(/obj/item/explosive/grenade/smokebomb = 25)
+
+
+
+/obj/machinery/vending/marine/cargo_guns/select_gamemode_equipment(gamemode)
+	return
+
+/obj/machinery/vending/marine/cargo_guns/Initialize()
+	. = ..()
+	GLOB.cargo_guns_vendors.Add(src)
+	GLOB.marine_vendors.Remove(src)
+
+/obj/machinery/vending/marine/cargo_guns/Destroy()
+	. = ..()
+	GLOB.cargo_guns_vendors.Remove(src)
+
+
+
+
+/obj/machinery/vending/marine/cargo_ammo
+	name = "\improper Automated Munition Vendor"
+	desc = "A automated rack hooked up to a small supply of ammo magazines."
+	icon_state = "marinerequisitions"
+	icon_vend = "marinerequisitions-vend"
+	icon_deny = "marinerequisitions"
+	wrenchable = FALSE
+	products = list(
+		/obj/item/ammo_magazine/pistol/standard_pistol = 50,
+		/obj/item/ammo_magazine/revolver/standard_revolver = 50,
+		/obj/item/ammo_magazine/pistol/standard_heavypistol = 50,
+		/obj/item/ammo_magazine/pistol/vp70 = 50,
+		/obj/item/ammo_magazine/smg/standard_smg = 50,
+		/obj/item/ammo_magazine/smg/standard_machinepistol = 50,
+		/obj/item/ammo_magazine/rifle/standard_carbine = 50,
+		/obj/item/ammo_magazine/rifle/standard_assaultrifle = 50,
+		/obj/item/ammo_magazine/standard_lmg = 50,
+		/obj/item/ammo_magazine/standard_gpmg = 50,
+		/obj/item/ammo_magazine/rifle/standard_dmr = 50,
+		/obj/item/ammo_magazine/rifle/standard_br = 50,
+		/obj/item/cell/lasgun/lasrifle = 50,
+		/obj/item/ammo_magazine/rifle/chamberedrifle = 50,
+		/obj/item/ammo_magazine/shotgun = 50,
+		/obj/item/ammo_magazine/shotgun/buckshot = 50,
+		/obj/item/ammo_magazine/shotgun/flechette = 50,
+		/obj/item/ammo_magazine/rifle/tx15_slug = 50,
+		/obj/item/ammo_magazine/rifle/tx15_flechette = 50,
+		/obj/item/ammo_magazine/pistol/standard_pocketpistol = 50,
+		/obj/item/ammo_magazine/flamer_tank/large = 10,
+		/obj/item/ammo_magazine/standard_smartmachinegun = 2,
+		/obj/item/ammo_magazine/flamer_tank = 10,
+		/obj/item/ammo_magazine/smg/ppsh/ = 30,
+		/obj/item/ammo_magazine/smg/ppsh/extended = 10,
+		/obj/item/ammo_magazine/rifle/bolt = 7,
+		/obj/item/ammo_magazine/shotgun/mbx900 = 10,
+		/obj/item/ammo_magazine/shotgun/mbx900/buckshot = 10,
+
+	)
+	premium = list()
+
+
+/obj/machinery/vending/marine/cargo_ammo/select_gamemode_equipment(gamemode)
+	return
+
+/obj/machinery/vending/marine/cargo_ammo/Initialize()
+	. = ..()
+	GLOB.cargo_ammo_vendors.Add(src)
+	GLOB.marine_vendors.Remove(src)
+
+/obj/machinery/vending/marine/cargo_ammo/Destroy()
+	. = ..()
+	GLOB.cargo_ammo_vendors.Remove(src)
+
+/obj/machinery/vending/lasgun
+	name = "\improper Lasrifle Field Charger"
+	desc = "An automated power cell dispenser and charger. Used to recharge energy weapon power cells, including in the field. Has an internal battery that charges off the power grid when wrenched down."
+	icon_state = "lascharger"
+	icon_vend = "lascharger-vend"
+	icon_deny = "lascharger-denied"
+	wrenchable = TRUE
+	drag_delay = FALSE
+	anchored = FALSE
+	idle_power_usage = 1
+	active_power_usage = 50
+	machine_current_charge = 50000 //integrated battery for recharging energy weapons. Normally 10000.
+	machine_max_charge = 50000
+
+	product_ads = "Lasrifle running low? Recharge here!;Need a charge?;Power up!;Electrifying!;Empower yourself!"
+	products = list(
+		/obj/item/cell/lasgun/lasrifle = 10,
+		/obj/item/cell/lasgun/lasrifle/highcap = 2,
+	)
+
+	contraband =   list()
+
+	premium = list()
+
+	prices = list()
+
+/obj/machinery/vending/lasgun/Initialize()
+	. = ..()
+	update_icon()
+
+/obj/machinery/vending/lasgun/update_icon()
+	if(machine_max_charge)
+		switch(machine_current_charge / max(1,machine_max_charge))
+			if(0)
+				icon_state = "lascharger-off"
+			if(1 to 0.76)
+				icon_state = "lascharger"
+			if(0.75 to 0.51)
+				icon_state = "lascharger_75"
+			if(0.50 to 0.26)
+				icon_state = "lascharger_50"
+			if(0.25 to 0.01)
+				icon_state = "lascharger_25"
+
+/obj/machinery/vending/lasgun/examine(mob/user)
+	. = ..()
+	to_chat(user, "<b>It has [machine_current_charge] of [machine_max_charge] charge remaining.</b>")
+
+
+/obj/machinery/vending/lasgun/MouseDrop_T(atom/movable/A, mob/user)
+	if(machine_stat & (BROKEN|NOPOWER))
+		return
+
+	if(user.stat || user.restrained() || user.lying_angle)
+		return
+
+	if(get_dist(user, src) > 1 || get_dist(src, A) > 1)
+		return
+
+	var/obj/item/I = A
+	if(istype(I, /obj/item/cell/lasgun))
+		stock(I, user, TRUE)
+	else
+		stock(I, user)
+
+/obj/machinery/vending/lasgun/stock(obj/item/item_to_stock, mob/user, recharge = FALSE)
+	var/datum/data/vending_product/R //Let's try with a new datum.
+	//More accurate comparison between absolute paths.
+	for(R in (product_records + hidden_records + coin_records))
+		if(item_to_stock.type == R.product_path && !istype(item_to_stock,/obj/item/storage)) //Nice try, specialists/engis
+			if(istype(item_to_stock, /obj/item/cell/lasgun) && recharge)
+				if(!recharge_lasguncell(item_to_stock, user))
+					return //Can't recharge so cancel out
+
+			if(item_to_stock.loc == user) //Inside the mob's inventory
+				if(item_to_stock.flags_item & WIELDED)
+					item_to_stock.unwield(user)
+				user.temporarilyRemoveItemFromInventory(item_to_stock)
+
+			if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
+				var/obj/item/storage/S = item_to_stock.loc
+				S.remove_from_storage(item_to_stock, user.loc)
+
+			qdel(item_to_stock)
+			if(!recharge)
+				user.visible_message("<span class='notice'>[user] stocks [src] with \a [R.product_name].</span>",
+				"<span class='notice'>You stock [src] with \a [R.product_name].</span>")
+			R.amount++
+			updateUsrDialog()
+			break //We found our item, no reason to go on.
+
+/obj/machinery/vending/lasgun/proc/recharge_lasguncell(obj/item/cell/lasgun/A, mob/user)
+	var/recharge_cost = (A.maxcharge - A.charge)
+	if(recharge_cost > machine_current_charge)
+		to_chat(user, "<span class='warning'>[A] cannot be recharged; [src] has inadequate charge remaining: [machine_current_charge] of [machine_max_charge].</span>")
+		return FALSE
+	else
+		to_chat(user, "<span class='warning'>You insert [A] into [src] to be recharged.</span>")
+		if(icon_vend)
+			flick(icon_vend,src)
+		playsound(loc, 'sound/machines/hydraulics_1.ogg', 25, 0, 1)
+		machine_current_charge -= min(machine_current_charge, recharge_cost)
+		to_chat(user, "<span class='notice'>This dispenser has [machine_current_charge] of [machine_max_charge] remaining.</span>")
+		update_icon()
+		return TRUE
+
+
+/obj/machinery/vending/marineFood
+	name = "\improper Marine Food and Drinks Vendor"
+	desc = "Standard Issue Food and Drinks Vendor, containing standard military food and drinks."
+	icon_state = "sustenance"
+	wrenchable = FALSE
+	products = list(
+		/obj/item/reagent_containers/food/snacks/protein_pack = 50,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal1 = 15,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal2 = 15,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal3 = 15,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal4 = 15,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal6 = 15,
+		/obj/item/storage/box/MRE = 10,
+		/obj/item/reagent_containers/food/drinks/flask = 5,
+	)
+//Christmas inventory
+/*
+					/obj/item/reagent_containers/food/snacks/mre_pack/xmas1 = 25,
+					/obj/item/reagent_containers/food/snacks/mre_pack/xmas2 = 25,
+					/obj/item/reagent_containers/food/snacks/mre_pack/xmas3 = 25)*/
+	contraband = list(
+		/obj/item/reagent_containers/food/drinks/flask/marine = 10,
+					/obj/item/reagent_containers/food/snacks/mre_pack/meal5 = 15)
+	vend_delay = 15
+	//product_slogans = "Standard Issue Marine food!;It's good for you, and not the worst thing in the world.;Just fucking eat it.;"
+	product_ads = "Try the cornbread.;Try the pizza.;Try the pasta.;Try the tofu, wimp.;Try the pork."
+
+
+/obj/machinery/vending/MarineMed
+	name = "\improper MarineMed"
+	desc = "Marine Medical drug dispenser - Provided by Nanotrasen Pharmaceuticals Division(TM)."
+	icon_state = "marinemed"
+	icon_deny = "marinemed-deny"
+	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;All natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
+	req_one_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MEDPREP) //Medics, doctors and researchers can access
+	wrenchable = FALSE
+	products = list(
+		/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 6,
+		/obj/item/reagent_containers/hypospray/autoinjector/bicaridine = 6,
+		/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 6,
+		/obj/item/reagent_containers/hypospray/autoinjector/dylovene = 6,
+		/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 6,
+		/obj/item/reagent_containers/hypospray/autoinjector/kelotane = 6,
+		/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = 4,
+		/obj/item/reagent_containers/hypospray/autoinjector/tricordrazine = 8,
+		/obj/item/reagent_containers/hypospray/autoinjector/combat = 2,
+		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = 4,
+		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = 0,
+		/obj/item/storage/pill_bottle/bicaridine = 3,
+		/obj/item/storage/pill_bottle/dexalin = 3,
+		/obj/item/storage/pill_bottle/dylovene = 3,
+		/obj/item/storage/pill_bottle/kelotane = 3,
+		/obj/item/storage/pill_bottle/spaceacillin = 3,
+		/obj/item/storage/pill_bottle/inaprovaline = 3,
+		/obj/item/storage/pill_bottle/alkysine = 3,
+		/obj/item/storage/pill_bottle/tricordrazine = 3,
+		/obj/item/storage/pill_bottle/imidazoline = 3,
+		/obj/item/storage/pill_bottle/tramadol = 3,
+		/obj/item/storage/pill_bottle/russianRed = 5,
+		/obj/item/storage/pill_bottle/peridaxon = 2,
+		/obj/item/storage/pill_bottle/quickclot = 2,
+		/obj/item/storage/pill_bottle/hypervene = 2,
+		/obj/item/stack/medical/advanced/bruise_pack = 8,
+		/obj/item/stack/medical/bruise_pack = 8,
+		/obj/item/stack/medical/advanced/ointment = 8,
+		/obj/item/stack/medical/ointment = 8,
+		/obj/item/stack/medical/splint = 4,
+		/obj/item/healthanalyzer = 3,
+		/obj/item/bodybag/cryobag = 2,
+	)
+
+	contraband = list(
+		/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin = 3,
+		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired = 3,
+	)
+
+
+
+/obj/machinery/vending/MarineMed/Blood
+	name = "\improper MM Blood Dispenser"
+	desc = "Marine Med brand Blood Pack dispensery."
+	icon_state = "bloodvendor"
+	icon_deny = "bloodvendor-deny"
+	product_ads = "The best blood on the market!"
+	req_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY)
+	products = list(
+		/obj/item/reagent_containers/blood/APlus = 5,
+		/obj/item/reagent_containers/blood/AMinus = 5,
+		/obj/item/reagent_containers/blood/BPlus = 5,
+		/obj/item/reagent_containers/blood/BMinus = 5,
+		/obj/item/reagent_containers/blood/OPlus = 5,
+		/obj/item/reagent_containers/blood/OMinus = 5,
+		/obj/item/reagent_containers/blood/empty = 10,
+	)
+	contraband = list()
+
+/obj/machinery/vending/MarineMed/Blood/build_inventory(productlist[])
+	. = ..()
+	var/temp_list[] = productlist
+	var/obj/item/reagent_containers/blood/temp_path
+	var/datum/data/vending_product/R
+	var/blood_type
+	for(R in (product_records + hidden_records + coin_records))
+		if(R.product_path in temp_list)
+			temp_path = R.product_path
+			blood_type = initial(temp_path.blood_type)
+			R.product_name += blood_type? " [blood_type]" : ""
+			temp_list -= R.product_path
+			if(!temp_list.len) break
+
+/obj/machinery/vending/marine_medic
+	name = "\improper TerraGovTech Medic Vendor"
+	desc = "A marine medic equipment vendor"
+	product_ads = "They were gonna die anyway.;Let's get space drugged!"
+	req_access = list(ACCESS_MARINE_MEDPREP)
+	icon_state = "marinemed"
+	icon_deny = "marinemed-deny"
+	wrenchable = FALSE
+
+	products = list(
+		/obj/item/clothing/under/marine/corpsman = 4,
+		/obj/item/clothing/head/helmet/marine/corpsman = 4,
+		/obj/item/storage/backpack/marine/corpsman = 4,
+		/obj/item/storage/backpack/marine/satchel/corpsman = 4,
+		/obj/item/encryptionkey/med = 4,
+		/obj/item/storage/belt/medical = 4,
+		/obj/item/bodybag/cryobag = 4,
+		/obj/item/healthanalyzer = 4,
+		/obj/item/clothing/glasses/hud/health = 4,
+		/obj/item/storage/firstaid/regular = 4,
+		/obj/item/storage/firstaid/adv = 4,
+		/obj/item/storage/pouch/medical = 4,
+		/obj/item/storage/pouch/medkit = 4,
+		/obj/item/storage/pouch/magazine/large = 4,
+		/obj/item/storage/pouch/magazine/pistol/large = 4,
+		/obj/item/clothing/mask/gas = 4,
+		/obj/item/storage/pouch/pistol = 4,
+	)
+	contraband = list(/obj/item/reagent_containers/blood/OMinus = 1)
+
+
+/obj/machinery/vending/marine_special
+	name = "\improper TerraGovTech Specialist Vendor"
+	desc = "A marine specialist equipment vendor"
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	req_access = list(ACCESS_MARINE_SPECPREP)
+	icon_state = "specialist"
+	icon_deny = "specialist-deny"
+	wrenchable = FALSE
+	tokensupport = TOKEN_SPEC
+
+	products = list(
+		/obj/item/coin/marine/specialist = 1,
+		/obj/item/clothing/tie/storage/webbing = 1,
+		/obj/item/explosive/plastique = 2,
+		/obj/item/explosive/grenade/frag = 2,
+		/obj/item/explosive/grenade/incendiary = 2,
+		/obj/item/storage/pouch/magazine/large = 1,
+		/obj/item/storage/pouch/general/medium = 1,
+		/obj/item/clothing/mask/gas = 1,
+	)
+	contraband = list()
+	premium = list(
+		/obj/item/storage/box/spec/demolitionist = 1,
+		/obj/item/storage/box/spec/heavy_grenadier = 1,
+		/obj/item/storage/box/m42c_system = 1,
+		/obj/item/storage/box/m42c_system_Jungle = 1,
+		/obj/item/storage/box/spec/pyro = 1,
+		/obj/item/storage/box/spec/tracker = 1,
+	)
+	prices = list()
+
+
+/obj/machinery/vending/shared_vending/marine_special
+	name = "\improper TerraGovTech Specialist Vendor"
+	desc = "A marine specialist equipment vendor"
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	req_access = list(ACCESS_MARINE_SPECPREP)
+	icon_state = "specialist"
+	icon_deny = "specialist-deny"
+	wrenchable = FALSE
+	tokensupport = TOKEN_SPEC
+
+	products = list(/obj/item/coin/marine/specialist = 1)
+	contraband = list()
+	premium = list()
+	shared = list(
+		/obj/item/storage/box/spec/demolitionist = 1,
+		/obj/item/storage/box/spec/heavy_grenadier = 1,
+		/obj/item/storage/box/spec/sniper = 1,
+		/obj/item/storage/box/spec/scout = 1,
+		/obj/item/storage/box/spec/pyro = 1,
+		/obj/item/storage/box/spec/tracker = 1,
+	)
+	prices = list()
+
+
+/obj/machinery/vending/shared_vending/marine_engi
+	name = "\improper TerraGovTech Engineer System Vendor"
+	desc = "A marine engineering system vendor"
+	product_ads = "If it breaks, wrench it!;If it wrenches, weld it!;If it snips, snip it!"
+	req_access = list(ACCESS_MARINE_ENGPREP)
+	icon_state = "engiprep"
+	icon_deny = "engiprep-deny"
+	wrenchable = FALSE
+	tokensupport = TOKEN_ENGI
+
+	contraband = list(/obj/item/cell/super = 1)
+
+	shared = list(
+		/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
+		/obj/item/storage/box/sentry = 3,
+		/obj/item/storage/box/standard_hmg = 1,
+	)
+	prices = list()
+
+
+/obj/machinery/vending/marine_smartgun
+	name = "\improper TerraGovTech Smartgun Vendor"
+	desc = "A marine smartgun equipment vendor"
+	hacking_safety = 1
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	req_access = list(ACCESS_MARINE_SMARTPREP)
+	icon_state = "smartgunner"
+	icon_deny = "smartgunner-deny"
+	wrenchable = FALSE
+
+	products = list(
+		/obj/item/clothing/tie/storage/webbing = 1,
+		/obj/item/storage/box/t26_system = 1,
+		/obj/item/smartgun_powerpack = 1,
+		/obj/item/storage/pouch/magazine/large = 1,
+		/obj/item/clothing/mask/gas = 1,
+	)
+	contraband = list()
+	premium = list()
+	prices = list()
+
+/obj/machinery/vending/marine_leader
+	name = "\improper TerraGovTech Leader Vendor"
+	desc = "A marine leader equipment vendor"
+	hacking_safety = 1
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	req_access = list(ACCESS_MARINE_LEADER)
+	icon_state = "squadleader"
+	icon_deny = "squadleader-deny"
+	wrenchable = FALSE
+
+	products = list(
+		/obj/item/clothing/suit/storage/marine/leader = 1,
+		/obj/item/clothing/head/helmet/marine/leader = 1,
+		/obj/item/clothing/tie/storage/webbing = 1,
+		/obj/item/squad_beacon = 1,
+		/obj/item/squad_beacon/bomb = 1,
+		/obj/item/explosive/plastique = 1,
+		/obj/item/explosive/grenade/smokebomb = 3,
+		/obj/item/binoculars/tactical = 1,
+		/obj/item/motiondetector = 1,
+		/obj/item/ammo_magazine/pistol/hp = 2,
+		/obj/item/ammo_magazine/pistol/ap = 1,
+		/obj/item/storage/backpack/marine/satchel = 2,
+		/obj/item/weapon/gun/flamer = 2,
+		/obj/item/ammo_magazine/flamer_tank = 8,
+		/obj/item/storage/pouch/magazine/large = 1,
+		/obj/item/storage/pouch/general/large = 1,
+		/obj/item/storage/pouch/magazine/pistol/large = 1,
+		/obj/item/clothing/mask/gas = 1,
+		/obj/item/whistle = 1,
+		/obj/item/storage/box/zipcuffs = 2,
+	)
+
+
+/obj/machinery/vending/attachments
+	name = "\improper Terran Armories Attachments Vendor"
+	desc = "A subsidiary-owned vendor of weapon attachments."
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	icon_state = "robotics"
+	icon_deny = "robotics-deny"
+	wrenchable = FALSE
+
+	products = list(
+		/obj/item/attachable/bayonet = 25,
+		/obj/item/attachable/compensator = 25,
+		/obj/item/attachable/extended_barrel = 25,
+		/obj/item/attachable/heavy_barrel = 25,
+		/obj/item/attachable/suppressor = 25,
+
+		/obj/item/attachable/flashlight = 25,
+		/obj/item/attachable/magnetic_harness = 25,
+		/obj/item/attachable/reddot = 25,
+		/obj/item/attachable/scope/marine = 25,
+		/obj/item/attachable/scope/mini = 25,
+
+		/obj/item/attachable/angledgrip = 25,
+		/obj/item/attachable/bipod = 25,
+		/obj/item/attachable/burstfire_assembly = 25,
+		/obj/item/attachable/gyro = 25,
+		/obj/item/attachable/lasersight = 25,
+		/obj/item/attachable/verticalgrip = 25,
+
+		/obj/item/attachable/stock/t19stock = 25,
+		/obj/item/attachable/stock/t35stock = 25,
+		/obj/item/attachable/stock/tactical = 25,
+
+		/obj/item/attachable/attached_gun/flamer = 25,
+		/obj/item/attachable/attached_gun/shotgun = 25,
+		/obj/item/attachable/attached_gun/grenade = 25,
+	)
+
+/obj/machinery/vending/attachments/Initialize()
+	. = ..()
+	GLOB.attachment_vendors.Add(src)
+
+/obj/machinery/vending/attachments/Destroy()
+	. = ..()
+	GLOB.attachment_vendors.Remove(src)
+
+
+
+/obj/machinery/vending/armor_supply
+	name = "\improper Surplus Armor Equipment Vendor"
+	desc = "A automated equipment rack hooked up to a colossal storage of armor and accessories."
+	icon_state = "marineuniform"
+	icon_vend = "marineuniform_vend"
+	icon_deny = "marineuniform"
+
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	products = list(
+		/obj/item/clothing/under/marine/jaeger = 30,
+		/obj/item/clothing/suit/storage/marine/pasvest = 40,
+		/obj/item/clothing/suit/storage/marine/harness = 5,
+		/obj/item/clothing/suit/armor/vest/pilot = 20,
+		/obj/item/clothing/head/helmet/marine = 40,
+		/obj/item/clothing/head/helmet/marine/heavy = 10,
+		/obj/item/clothing/mask/rebreather = 10,
+		/obj/item/clothing/mask/breath = 10,
+		/obj/item/clothing/mask/gas = 10,
+		/obj/item/clothing/mask/gas/tactical = 10,
+		/obj/item/clothing/mask/gas/tactical/coif = 10,
+		/obj/item/armor_module/storage/general = 20,
+		/obj/item/armor_module/storage/engineering = 20,
+		/obj/item/armor_module/storage/medical = 20,
+		/obj/item/clothing/suit/modular = 20,
+		/obj/item/armor_module/armor/chest/marine/skirmisher = 20,
+		/obj/item/armor_module/armor/chest/marine = 20,
+		/obj/item/armor_module/armor/chest/marine/eva = 20,
+		/obj/item/armor_module/armor/chest/marine/assault = 20,
+		/obj/item/armor_module/armor/chest/marine/assault/eod = 20,
+		/obj/item/armor_module/armor/arms/marine/skirmisher = 20,
+		/obj/item/armor_module/armor/arms/marine = 20,
+		/obj/item/armor_module/armor/arms/marine/eva = 20,
+		/obj/item/armor_module/armor/arms/marine/assault = 20,
+		/obj/item/armor_module/armor/arms/marine/eod = 20,
+		/obj/item/armor_module/armor/legs/marine/skirmisher = 20,
+		/obj/item/armor_module/armor/legs/marine = 20,
+		/obj/item/armor_module/armor/legs/marine/eva = 20,
+		/obj/item/armor_module/armor/legs/marine/assault = 20,
+		/obj/item/armor_module/armor/legs/marine/eod = 20,
+		/obj/item/clothing/head/modular/marine/skirmisher = 20,
+		/obj/item/clothing/head/modular/marine = 20,
+		/obj/item/clothing/head/modular/marine/eva = 20,
+		/obj/item/clothing/head/modular/marine/eva/skull = 20,
+		/obj/item/clothing/head/modular/marine/assault = 20,
+		/obj/item/clothing/head/modular/marine/eod = 20,
+		/obj/item/helmet_module/welding = 20,
+		/obj/item/helmet_module/binoculars = 20,
+		/obj/item/helmet_module/antenna = 20,
+		/obj/item/facepaint/green = 20,
+	)
+
+	prices = list()
+
+/obj/machinery/vending/uniform_supply
+	name = "\improper Surplus Clothing Vendor"
+	desc = "A automated equipment rack hooked up to a colossal storage of clothing and accessories."
+	icon_state = "marineuniform"
+	icon_vend = "marineuniform_vend"
+	icon_deny = "marineuniform"
+	var/squad_tag = ""
+
+	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
+	products = list(
+		/obj/item/storage/large_holster/machete/full = 10,
+		/obj/item/clothing/shoes/marine = 20,
+		/obj/item/clothing/under/marine/standard = 20,
+		/obj/item/clothing/under/marine/jaeger = 30,
+		/obj/item/storage/backpack/marine/standard = 10,
+		/obj/item/storage/backpack/marine/satchel = 10,
+		/obj/item/tool/weldpack/marinestandard = 10,
+		/obj/item/clothing/gloves/marine = 20,
+		/obj/item/clothing/head/slouch = 40,
+		/obj/item/clothing/glasses/mgoggles = 10,
+		/obj/item/clothing/glasses/mgoggles/prescription = 10,
+		/obj/item/radio/headset/mainship/marine/generic = 20,
+		/obj/item/clothing/mask/rebreather/scarf = 10,
+		/obj/item/clothing/mask/bandanna/skull = 10,
+		/obj/item/clothing/mask/bandanna/green = 10,
+		/obj/item/clothing/mask/bandanna/white = 10,
+		/obj/item/clothing/mask/bandanna/black = 10,
+		/obj/item/clothing/mask/bandanna = 10,
+		/obj/item/clothing/mask/bandanna/alpha = 10,
+		/obj/item/clothing/mask/bandanna/bravo = 10,
+		/obj/item/clothing/mask/bandanna/charlie = 10,
+		/obj/item/clothing/mask/bandanna/delta = 10,
+		/obj/item/clothing/mask/rebreather = 10,
+		/obj/item/clothing/mask/breath = 10,
+		/obj/item/clothing/mask/gas = 10,
+		/obj/item/clothing/mask/gas/tactical = 10,
+		/obj/item/clothing/mask/gas/tactical/coif = 10,
+		/obj/item/storage/belt/marine = 10,
+		/obj/item/storage/belt/shotgun = 10,
+		/obj/item/storage/belt/grenade = 10,
+		/obj/item/storage/belt/knifepouch = 10,
+		/obj/item/belt_harness/marine = 10,
+		/obj/item/storage/belt/sparepouch = 10,
+		/obj/item/storage/belt/gun/pistol/standard_pistol = 10,
+		/obj/item/storage/belt/gun/revolver/standard_revolver = 10,
+		/obj/item/storage/pouch/pistol = 10,
+		/obj/item/storage/pouch/magazine/large = 5,
+		/obj/item/storage/pouch/magazine/pistol/large = 5,
+		/obj/item/storage/pouch/shotgun = 10,
+		/obj/item/storage/pouch/flare = 10,
+		/obj/item/storage/pouch/grenade = 10,
+		/obj/item/storage/pouch/explosive = 10,
+		/obj/item/storage/pouch/firstaid = 10,
+		/obj/item/storage/pouch/syringe = 5,
+		/obj/item/storage/pouch/medkit = 15,
+		/obj/item/storage/pouch/autoinjector = 10,
+		/obj/item/storage/pouch/construction = 10,
+		/obj/item/storage/pouch/electronics = 10,
+		/obj/item/storage/pouch/tools = 10,
+		/obj/item/storage/pouch/field_pouch = 10,
+		/obj/item/storage/pouch/general/large = 10,
+		/obj/item/storage/pouch/document = 10,
+		/obj/item/clothing/tie/storage/black_vest = 10,
+		/obj/item/clothing/tie/storage/brown_vest = 10,
+		/obj/item/clothing/tie/storage/white_vest/medic = 10,
+		/obj/item/clothing/tie/storage/webbing = 10,
+		/obj/item/clothing/tie/holster = 10,
+		/obj/item/flashlight/combat = 10,
+		/obj/item/clothing/under/whites = 50,
+		/obj/item/clothing/head/white_dress = 50,
+		/obj/item/clothing/shoes/white = 50,
+		/obj/item/clothing/gloves/white = 50,
+	)
+
+	prices = list()
+
+/obj/machinery/vending/dress_supply
+	name = "\improper TerraGovTech dress uniform vendor"
+	desc = "A automated rack hooked up to a colossal storage of dress uniforms."
+	icon_state = "marineuniform"
+	icon_vend = "marineuniform_vend"
+	icon_deny = "marineuniform"
+	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PREP, ACCESS_MARINE_CARGO)
+	product_ads = "Hey! You! Stop looking like a turtle and start looking like a TRUE soldier!;Dress whites, fresh off the ironing board!;Why kill in armor when you can kill in style?;These uniforms are so sharp you'd cut yourself just looking at them!"
+	products = list(
+		/obj/item/clothing/under/whites = 50,
+		/obj/item/clothing/head/white_dress = 50,
+		/obj/item/clothing/shoes/white = 50,
+		/obj/item/clothing/gloves/white = 50,
+	)
+
+/obj/machinery/vending/uniform_supply/Initialize()
+	. = ..()
+
+/obj/machinery/vending/uniform_supply/Destroy()
+	. = ..()
+	GLOB.marine_vendors.Remove(src)

--- a/supplypacks.dm
+++ b/supplypacks.dm
@@ -1,0 +1,1431 @@
+//SUPPLY PACKS
+//NOTE: only secure crate types use the access var (and are lockable)
+//NOTE: Contraband is obtainable through modified supplycomp circuitboards.
+//NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
+//NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
+
+GLOBAL_LIST_INIT(all_supply_groups, list("Operations", "Weapons", "Attachments", "Ammo", "Armor", "Clothing", "Medical", "Engineering", "Supplies", "Imports"))
+
+/datum/supply_packs
+	var/name
+	var/notes
+	var/list/contains = list()
+	var/cost
+	var/obj/containertype
+	var/access
+	var/hidden = FALSE
+	var/contraband = FALSE
+	var/group
+	var/randomised_num_contained = 0 //Randomly picks X of items out of the contains list instead of using all.
+
+/datum/supply_packs/proc/generate(atom/movable/location)
+	for(var/i in contains)
+		var/atom/movable/AM = i
+		new AM(location)
+
+
+/*******************************************************************************
+OPERATIONS
+*******************************************************************************/
+/datum/supply_packs/operations
+	group = "Operations"
+	containertype = /obj/structure/closet/crate
+
+/datum/supply_packs/operations/beacons_supply
+	name = "supply beacon"
+	contains = list(/obj/item/squad_beacon)
+	cost = 10
+
+/datum/supply_packs/operations/beacons_orbital
+	name = "orbital beacon"
+	contains = list(/obj/item/squad_beacon/bomb)
+	cost = 30
+
+/datum/supply_packs/operations/fulton_extraction_pack
+	name = "fulton extraction pack"
+	contains = list(/obj/item/fulton_extraction_pack)
+	cost = 5
+
+/datum/supply_packs/operations/cas_flares
+	name = "CAS flare pack"
+	contains = list(/obj/item/storage/box/m94/cas)
+	cost = 10
+
+/datum/supply_packs/operations/binoculars_regular
+	name = "binoculars"
+	contains = list(/obj/item/binoculars)
+	cost = 15
+
+/datum/supply_packs/operations/binoculars_tatical
+	name = "tactical binoculars crate"
+	contains = list(/obj/item/binoculars/tactical)
+	cost = 30
+
+/datum/supply_packs/operations/motion_detector
+	name = "motion detector crate"
+	contains = list(/obj/item/motiondetector/scout)
+	cost = 20
+
+/datum/supply_packs/operations/flares
+	name = "2 flare packs"
+	notes = "Contains 14 flares"
+	contains = list(
+		/obj/item/storage/box/m94,
+		/obj/item/storage/box/m94,
+	)
+	cost = 2
+
+/datum/supply_packs/operations/tarps
+	name = "V1 thermal-dampening tarp"
+	contains = list(/obj/item/bodybag/tarp)
+	cost = 6
+
+/datum/supply_packs/operations/deployablecams
+	name = "3 Deployable Cameras"
+	contains = list(
+		/obj/item/deployable_camera,
+		/obj/item/deployable_camera,
+		/obj/item/deployable_camera,
+	)
+	cost = 6
+
+/datum/supply_packs/operations/exportpad
+	name = "ASRS Bluespace Export Point"
+	contains = list(/obj/machinery/exportpad)
+	cost = 50
+
+/datum/supply_packs/operations/alpha
+	name = "Alpha Supply Crate"
+	contains = list(/obj/structure/closet/crate/alpha)
+	cost = 5
+	containertype = null
+
+/datum/supply_packs/operations/bravo
+	name = "Bravo Supply Crate"
+	contains = list(/obj/structure/closet/crate/bravo)
+	cost = 5
+	containertype = null
+
+/datum/supply_packs/operations/charlie
+	name = "Charlie Supply Crate"
+	contains = list(/obj/structure/closet/crate/charlie)
+	cost = 5
+	containertype = null
+
+/datum/supply_packs/operations/delta
+	name = "Delta Supply Crate"
+	contains = list(/obj/structure/closet/crate/delta)
+	cost = 5
+	containertype = null
+
+/datum/supply_packs/operations/warhead_cluster
+	name = "Cluster orbital warhead"
+	contains = list(/obj/structure/ob_ammo/warhead/cluster)
+	cost = 40
+	containertype = null
+
+/datum/supply_packs/operations/warhead_explosive
+	name = "HE orbital warhead"
+	contains = list(/obj/structure/ob_ammo/warhead/explosive)
+	cost = 40
+	containertype = null
+
+/datum/supply_packs/operations/warhead_incendiary
+	name = "Incendiary orbital warhead"
+	contains = list(/obj/structure/ob_ammo/warhead/incendiary)
+	cost = 40
+	containertype = null
+
+/datum/supply_packs/operations/warhead_plasmaloss
+	name = "Plasma draining orbital warhead"
+	contains = list(/obj/structure/ob_ammo/warhead/plasmaloss)
+	cost = 25
+	containertype = null
+
+/datum/supply_packs/operations/ob_fuel
+	name = "Solid fuel"
+	contains = list(/obj/structure/ob_ammo/ob_fuel)
+	cost = 10
+	containertype = null
+/*******************************************************************************
+WEAPONS
+*******************************************************************************/
+
+/datum/supply_packs/weapons
+	group = "Weapons"
+	containertype = /obj/structure/closet/crate/weapon
+
+/datum/supply_packs/weapons/sentry
+	name = "UA 571-C Base Defense Sentry"
+	contains = list(/obj/item/storage/box/sentry)
+	cost = 120
+
+/datum/supply_packs/weapons/minisentry
+	name = "UA-580 Portable Sentry"
+	contains = list(/obj/item/storage/box/minisentry)
+	cost = 60
+
+/datum/supply_packs/weapons/m56d_emplacement
+	name = "TL-102 Mounted Heavy Smartgun"
+	contains = list(/obj/item/storage/box/standard_hmg)
+	cost = 80
+
+/datum/supply_packs/weapons/quadlauncher
+	name = "M57A4 Quad Thermobaric Launcher"
+	contains = list(/obj/item/weapon/gun/launcher/rocket/m57a4)
+	cost = 250
+
+/datum/supply_packs/weapons/tesla
+	name = "Energy Ball Rifle"
+	contains = list(
+		/obj/item/weapon/gun/energy/lasgun/tesla,
+		/obj/item/cell/lasgun/tesla,
+		/obj/item/cell/lasgun/tesla,
+	)
+	cost = 60
+
+/datum/supply_packs/weapons/recoillesskit
+	name = "Recoilless rifle kit"
+	contains = list(/obj/item/storage/box/recoilless_system)
+	cost = 40
+
+
+/datum/supply_packs/weapons/specgrenadier
+	name = "Grenadier Specialist kit"
+	contains = list(/obj/item/weapon/gun/launcher/m92)
+	cost = 80
+
+/datum/supply_packs/weapons/specscoutm4ra
+	name = "Scout Specialist kit (M4RA)"
+	contains = list(/obj/item/weapon/gun/rifle/m4ra)
+	cost = 80
+
+/datum/supply_packs/weapons/specdemo
+	name = "Demolitionist Specialist kit"
+	contains = list(/obj/item/weapon/gun/launcher/rocket/sadar)
+	cost = 90
+
+/datum/supply_packs/weapons/autosniper
+	name = "IFF Auto Sniper kit"
+	contains = list(
+		/obj/item/weapon/gun/rifle/standard_autosniper,
+		/obj/item/ammo_magazine/rifle/autosniper,
+		/obj/item/ammo_magazine/rifle/autosniper,
+	)
+	cost = 70
+
+/datum/supply_packs/weapons/specminigun
+	name = "MIC-A7 Vindicator Minigun"
+	contains = list(/obj/item/weapon/gun/minigun)
+	cost = 80
+
+/datum/supply_packs/weapons/smartgun
+	name = "T-29 Smart Machinegun"
+	contains = list(/obj/item/weapon/gun/rifle/standard_smartmachinegun)
+	cost = 40
+
+/datum/supply_packs/weapons/flamethrower
+	name = "TL-84 Flamethrower"
+	contains = list(/obj/item/weapon/gun/flamer/marinestandard)
+	cost = 15
+
+/datum/supply_packs/weapons/mateba
+	name = "Mateba Autorevolver belt"
+	contains = list(/obj/item/storage/belt/gun/mateba/full)
+	notes = "Contains 6 speedloaders"
+	cost = 15
+
+/datum/supply_packs/weapons/explosives_mines
+	name = "claymore mines"
+	notes = "Contains 5 mines"
+	contains = list(/obj/item/storage/box/explosive_mines)
+	cost = 15
+
+/datum/supply_packs/weapons/explosives_hedp
+	name = "M40 HEDP high explosive grenade box crate"
+	notes = "Contains 25 grenades"
+	contains = list(/obj/item/storage/box/nade_box)
+	cost = 50
+
+/datum/supply_packs/weapons/explosives_hidp
+	name = "M40 HIDP incendiary explosive grenade box crate"
+	notes = "Contains 25 grenades"
+	contains = list(/obj/item/storage/box/nade_box/HIDP)
+	cost = 50
+
+/datum/supply_packs/weapons/explosives_m15
+	name = "M15 fragmentation grenade box crate"
+	notes = "Contains 15 grenades"
+	contains = list(/obj/item/storage/box/nade_box/M15)
+	cost = 50
+
+/datum/supply_packs/weapons/explosives_hsdp
+	name = "M40 HSDP white phosphorous grenade box crate"
+	notes = "Contains 15 grenades"
+	contains = list(/obj/item/storage/box/nade_box/phos)
+	cost = 70
+
+/datum/supply_packs/weapons/plastique
+	name = "C4 plastic explosive"
+	contains = list(/obj/item/explosive/plastique)
+	cost = 5
+
+/datum/supply_packs/weapons/mortar
+	name = "M402 mortar crate"
+	contains = list(/obj/item/mortar_kit)
+	cost = 40
+
+/datum/supply_packs/weapons/detpack
+	name = "detpack explosives"
+	contains = list(
+		/obj/item/detpack,
+		/obj/item/detpack,
+		/obj/item/assembly/signaler,
+	)
+	cost = 15
+
+/*******************************************************************************
+ATTACHMENTS
+*******************************************************************************/
+/datum/supply_packs/attachments
+	group = "Attachments"
+	containertype = /obj/structure/closet/crate
+
+/datum/supply_packs/attachments/rail_reddot
+	name = "red-dot sight attachment"
+	contains = list(/obj/item/attachable/reddot)
+	cost = 1
+
+/datum/supply_packs/attachments/rail_scope
+	name = "railscope attachment"
+	contains = list(/obj/item/attachable/scope)
+	cost = 1
+
+/datum/supply_packs/attachments/rail_miniscope
+	name = "mini railscope attachment"
+	contains = list(/obj/item/attachable/scope/mini)
+	cost = 1
+
+/datum/supply_packs/attachments/rail_magneticharness
+	name = "magnetic harness attachment"
+	contains = list(/obj/item/attachable/magnetic_harness)
+	cost = 1
+
+/datum/supply_packs/attachments/muzzle_suppressor
+	name = "suppressor attachment"
+	contains = list(/obj/item/attachable/suppressor)
+	cost = 1
+
+/datum/supply_packs/attachments/muzzle_bayonet
+	name = "bayonet attachment"
+	contains = list(/obj/item/attachable/bayonet)
+	cost = 1
+
+/datum/supply_packs/attachments/muzzle_extended
+	name = "extended barrel attachment"
+	contains = list(/obj/item/attachable/extended_barrel)
+	cost = 1
+
+/datum/supply_packs/attachments/muzzle_heavy
+	name = "barrel charger attachment"
+	contains = list(/obj/item/attachable/heavy_barrel)
+	cost = 1
+
+/datum/supply_packs/attachments/muzzle_compensator
+	name = "compensator attachment"
+	contains = list(/obj/item/attachable/compensator)
+	cost = 1
+
+/datum/supply_packs/attachments/lasersight
+	name = "lasersight attachment"
+	contains = list(/obj/item/attachable/lasersight)
+	cost = 1
+
+/datum/supply_packs/attachments/angledgrip
+	name = "angledgrip attachment"
+	contains = list(/obj/item/attachable/angledgrip)
+	cost = 1
+
+/datum/supply_packs/attachments/verticalgrip
+	name = "verticalgrip attachment"
+	contains = list(/obj/item/attachable/verticalgrip)
+	cost = 1
+
+/datum/supply_packs/attachments/underbarrel_gyro
+	name = "gyroscopic stabilizer attachment"
+	contains = list(/obj/item/attachable/gyro)
+	cost = 1
+
+/datum/supply_packs/attachments/underbarrel_bipod
+	name = "bipod attachment"
+	contains = list(/obj/item/attachable/bipod)
+	cost = 1
+
+/datum/supply_packs/attachments/underbarrel_shotgun
+	name = "underbarrel shotgun attachment"
+	contains = list(/obj/item/attachable/attached_gun/shotgun)
+	cost = 1
+
+/datum/supply_packs/attachments/underbarrel_flamer
+	name = "underbarrel flamer attachment"
+	contains = list(/obj/item/attachable/attached_gun/flamer)
+	cost = 1
+
+/datum/supply_packs/attachments/underbarrel_burstfire_assembly
+	name = "burstfire assembly attachment"
+	contains = list(/obj/item/attachable/burstfire_assembly)
+	cost = 1
+
+/datum/supply_packs/attachments/stock_shotgun
+	name = "shotgun stock attachment"
+	contains = list(/obj/item/attachable/stock/t35stock)
+	cost = 1
+
+/datum/supply_packs/attachments/stock_smg
+	name = "combat shotgun stock attachment crate"
+	contains = list(/obj/item/attachable/stock/tactical)
+	cost = 1
+
+/*******************************************************************************
+AMMO
+*******************************************************************************/
+/datum/supply_packs/ammo
+	containertype = /obj/structure/closet/crate/ammo
+	group = "Ammo"
+
+/datum/supply_packs/ammo
+	name = "Energy Rifle cells 3x"
+	contains = list(
+		/obj/item/cell/lasgun/tesla,
+		/obj/item/cell/lasgun/tesla,
+		/obj/item/cell/lasgun/tesla,
+	)
+	cost = 30
+
+/datum/supply_packs/ammo/boxslug
+	name = "Slug Ammo Box"
+	contains = list(/obj/item/shotgunbox)
+	cost = 20
+
+/datum/supply_packs/ammo/boxbuckshot
+	name = "Buckshot Ammo Box"
+	contains = list(/obj/item/shotgunbox/buckshot)
+	cost = 20
+
+/datum/supply_packs/ammo/boxflechette
+	name = "Flechette Ammo Box"
+	contains = list(/obj/item/shotgunbox/flechette)
+	cost = 20
+
+/datum/supply_packs/ammo/boxcarbine
+	name = "T-18 Carbine Ammo Box"
+	contains = list(/obj/item/ammobox)
+	cost = 20
+
+/datum/supply_packs/ammo/boxrifle
+	name = "T-12 Assault Rifle Ammo Box"
+	contains = list(/obj/item/ammobox/standard_rifle)
+	cost = 20
+
+/datum/supply_packs/ammo/boxsmg
+	name = "T-90 SMG Ammo Box"
+	contains = list(/obj/item/ammobox/standard_smg)
+	cost = 20
+
+/datum/supply_packs/ammo/boxmachpistol
+	name = "T-19 Machine Pistol Ammo Box"
+	contains = list(/obj/item/ammobox/standard_machinepistol)
+	cost = 20
+
+/datum/supply_packs/ammo/boxlmg
+	name = "T-42 LMG Ammo Box"
+	contains = list(/obj/item/ammobox/standard_lmg)
+	cost = 20
+
+/datum/supply_packs/ammo/boxdmr
+	name = "T-64 DMR Ammo Box"
+	contains = list(/obj/item/ammobox/standard_dmr)
+	cost = 20
+
+/datum/supply_packs/ammo/boxpistol
+	name = "TP-14 Pistol Ammo Box"
+	contains = list(/obj/item/ammobox/standard_pistol)
+	cost = 20
+
+/datum/supply_packs/ammo/mateba
+	name = "Mateba magazine"
+	contains = list(/obj/item/ammo_magazine/revolver/mateba)
+	cost = 3
+
+/datum/supply_packs/ammo/incendiaryslugs
+	name = "Box of Incendiary Slugs"
+	contains = list(/obj/item/ammo_magazine/shotgun/incendiary)
+	cost = 10
+
+/datum/supply_packs/ammo/quadlauncher
+	name = "M57A4 thermobaric rocket array"
+	contains = list(/obj/item/ammo_magazine/rocket/m57a4)
+	cost = 50
+
+/datum/supply_packs/ammo/scout_regular
+	name = "M4RA scout magazine"
+	contains = list(/obj/item/ammo_magazine/rifle/m4ra)
+	cost = 5
+
+/datum/supply_packs/ammo/scout_impact
+	name = "M4RA scout impact magazine"
+	contains = list(/obj/item/ammo_magazine/rifle/m4ra/impact)
+	cost = 7
+
+/datum/supply_packs/ammo/scout_incendiary
+	name = "M4RA scout incendiary magazine"
+	contains = list(/obj/item/ammo_magazine/rifle/m4ra/incendiary)
+	cost = 7
+
+/datum/supply_packs/ammo/scout_smart
+	name = "M4RA scout smart magazine"
+	contains = list(/obj/item/ammo_magazine/rifle/m4ra/smart)
+	cost = 7
+
+/datum/supply_packs/ammo/autosniper_regular
+	name = "T-81 IFF sniper magazine"
+	contains = list(/obj/item/ammo_magazine/rifle/autosniper)
+	cost = 3
+
+/datum/supply_packs/ammo/rpg_regular
+	name = "T-152 RPG HE rocket"
+	contains = list(/obj/item/ammo_magazine/rocket/sadar)
+	cost = 7
+
+/datum/supply_packs/ammo/rpg_ap
+	name = "T-152 RPG AP rocket"
+	contains = list(/obj/item/ammo_magazine/rocket/sadar/ap)
+	cost = 7
+
+/datum/supply_packs/ammo/rpg_wp
+	name = "T-152 RPG WP rocket"
+	contains = list(/obj/item/ammo_magazine/rocket/sadar/wp)
+	cost = 7
+
+/datum/supply_packs/ammo/shell_regular
+	name = "T-160 RR HE shell"
+	contains = list(/obj/item/ammo_magazine/rocket/recoilless)
+	cost = 3
+
+/datum/supply_packs/ammo/shell_le
+	name = "T-160 RR LE shell"
+	contains = list(/obj/item/ammo_magazine/rocket/recoilless/light)
+	cost = 3
+
+/datum/supply_packs/ammo/smartmachinegun
+	name = "T-29 smartmachinegun ammo"
+	contains = list(/obj/item/ammo_magazine/standard_smartmachinegun)
+	cost = 10
+
+/datum/supply_packs/ammo/sentry
+	name = "UA 571-C sentry ammunition"
+	contains = list(/obj/item/ammo_magazine/sentry)
+	cost = 10
+
+/datum/supply_packs/ammo/napalm
+	name = "TL-84 normal fuel tank"
+	contains = list(/obj/item/ammo_magazine/flamer_tank)
+	cost = 3
+
+/datum/supply_packs/ammo/mortar_ammo_he
+	name = "M402 mortar HE shell"
+	contains = list(/obj/item/mortal_shell/he)
+	cost = 2
+
+/datum/supply_packs/ammo/mortar_ammo_incend
+	name = "M402 mortar incendiary shell"
+	contains = list(/obj/item/mortal_shell/incendiary)
+	cost = 2
+
+/datum/supply_packs/ammo/mortar_ammo_flare
+	name = "M402 mortar flare shell"
+	contains = list(/obj/item/mortal_shell/flare)
+	cost = 1
+
+/datum/supply_packs/ammo/mortar_ammo_smoke
+	name = "M402 mortar smoke shell"
+	contains = list(/obj/item/mortal_shell/smoke)
+	cost = 1
+
+/datum/supply_packs/ammo/mortar_ammo_plasmaloss
+	name = "M402 mortar tanglefoot shell"
+	contains = list(/obj/item/mortal_shell/plasmaloss)
+	cost = 2
+
+/datum/supply_packs/ammo/minisentry
+	name = "UA-580 point defense sentry ammo"
+	contains = list(/obj/item/ammo_magazine/minisentry)
+	cost = 10
+
+/datum/supply_packs/ammo/m56d
+	name = "TL-102 mounted heavy smartgun ammo"
+	contains = list(/obj/item/ammo_magazine/standard_hmg)
+	cost = 10
+
+/datum/supply_packs/ammo/lasguncharger
+	name = "ColMarTech Lasrifle Field Charger"
+	contains = list(/obj/machinery/vending/lasgun)
+	cost = 50
+	containertype = null
+
+/datum/supply_packs/ammo/lasgun
+	name = "TX-73 lasrifle battery"
+	contains = list(/obj/item/cell/lasgun/lasrifle)
+	cost = 2
+
+/datum/supply_packs/ammo/lasgun_highcap
+	name = "TX-73 lasrifle highcap battery"
+	contains = list(/obj/item/cell/lasgun/lasrifle/highcap)
+	cost = 4
+
+/datum/supply_packs/ammo/minigun
+	name = "Vindicator Minigun Ammo Drum"
+	contains = list(/obj/item/ammo_magazine/minigun)
+	cost = 5
+
+
+/*******************************************************************************
+ARMOR
+*******************************************************************************/
+/datum/supply_packs/armor
+	group = "Armor"
+	containertype = /obj/structure/closet/crate
+
+/datum/supply_packs/armor/masks
+	name = "SWAT protective mask"
+	contains = list(/obj/item/clothing/mask/gas/swat)
+	cost = 5
+
+/datum/supply_packs/armor/riot
+	name = "Heavy Riot Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/armor/riot/marine,
+		/obj/item/clothing/head/helmet/riot,
+	)
+	cost = 30
+
+/datum/supply_packs/armor/marine_shield
+	name = "TL-172 Defensive Shield"
+	contains = list(/obj/item/weapon/shield/riot/marine)
+	cost = 10
+
+/datum/supply_packs/armor/b18
+	name = "B18 Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/storage/marine/specialist,
+		/obj/item/clothing/head/helmet/marine/specialist,
+	)
+	cost = 100
+
+/datum/supply_packs/armor/b17
+	name = "B17 Armor Set"
+	contains = list(
+		/obj/item/clothing/suit/storage/marine/B17,
+		/obj/item/clothing/head/helmet/marine/grenadier,
+	)
+	cost = 60
+
+/datum/supply_packs/armor/scout_cloak
+	name = "Scout Cloak"
+	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/scout)
+	cost = 50
+
+/datum/supply_packs/armor/sniper_cloak
+	name = "Sniper Cloak"
+	contains = list(/obj/item/storage/backpack/marine/satchel/scout_cloak/sniper)
+	cost = 50
+
+/datum/supply_packs/armor/grenade_belt
+	name = "High Capacity Grenade Belt"
+	contains = list(/obj/item/storage/belt/grenade/b17)
+	cost = 20
+
+// Modular armor + Attachments
+/datum/supply_packs/armor/modular/exosuit
+	name = "Jaeger exosuits"
+	contains = list(/obj/item/clothing/suit/modular)
+	cost = 1
+
+/datum/supply_packs/armor/modular/armor/infantry
+	name = "Jaeger Medium Infantry plates"
+	contains = list(
+		/obj/item/clothing/head/modular/marine,
+		/obj/item/armor_module/armor/chest/marine,
+		/obj/item/armor_module/armor/arms/marine,
+		/obj/item/armor_module/armor/legs/marine,
+	)
+	cost = 1
+
+/datum/supply_packs/armor/modular/armor/skirmisher
+	name = "Jaeger Light Skirmisher plates"
+	contains = list(
+		/obj/item/clothing/head/modular/marine/skirmisher,
+		/obj/item/armor_module/armor/chest/marine/skirmisher,
+		/obj/item/armor_module/armor/arms/marine/skirmisher,
+		/obj/item/armor_module/armor/legs/marine/skirmisher,
+	)
+	cost = 1
+
+/datum/supply_packs/armor/modular/armor/assault
+	name = "Jaeger Heavy Assault plates"
+	contains = list(
+		/obj/item/clothing/head/modular/marine/assault,
+		/obj/item/armor_module/armor/chest/marine/assault,
+		/obj/item/armor_module/armor/arms/marine/assault,
+		/obj/item/armor_module/armor/legs/marine/assault,
+	)
+	cost = 1
+
+/datum/supply_packs/armor/modular/helmet/infantry
+	name = "Jaeger heavy helmets"
+	contains = list(/obj/item/clothing/head/modular/marine)
+	cost = 1
+
+/datum/supply_packs/armor/modular/helmet/skirmisher
+	name = "Jaeger medium helmets"
+	contains = list(/obj/item/clothing/head/modular/marine/skirmisher)
+	cost = 1
+
+/datum/supply_packs/armor/modular/helmet/assault
+	name = "Jaeger light helmets"
+	contains = list(/obj/item/clothing/head/modular/marine/assault)
+	cost = 1
+
+/datum/supply_packs/armor/modular/storage
+	name = "Jaeger assorted storage modules"
+	contains = list(
+		/obj/item/armor_module/storage/general,
+		/obj/item/armor_module/storage/medical,
+		/obj/item/armor_module/storage/engineering,
+	)
+	cost = 3
+
+/datum/supply_packs/armor/modular/attachments/mixed
+	name = "Jaeger experimental mark 2 modules"
+	contains = list(
+		/obj/item/armor_module/attachable/valkyrie_autodoc,
+		/obj/item/armor_module/attachable/fire_proof,
+		/obj/item/armor_module/attachable/tyr_extra_armor,
+		/obj/item/armor_module/attachable/mimir_environment_protection,
+		/obj/item/armor_module/attachable/better_shoulder_lamp,
+		/obj/item/armor_module/attachable/hlin_explosive_armor,
+	)
+	cost = 40
+
+/datum/supply_packs/armor/modular/attachments/lamp
+	name = "Jaeger baldur modules"
+	contains = list(
+		/obj/item/armor_module/attachable/better_shoulder_lamp,
+	)
+	cost = 10
+
+/datum/supply_packs/armor/modular/attachments/valkyrie_autodoc
+	name = "Jaeger valkyrie modules"
+	contains = list(
+		/obj/item/armor_module/attachable/valkyrie_autodoc,
+	)
+	cost = 12
+
+/datum/supply_packs/armor/modular/attachments/fire_proof
+	name = "Jaeger surt modules"
+	contains = list(
+		/obj/item/armor_module/attachable/fire_proof,
+	)
+	cost = 12
+
+/datum/supply_packs/armor/modular/attachments/tyr_extra_armor
+	name = "Jaeger tyr mark 2 modules"
+	contains = list(
+		/obj/item/armor_module/attachable/tyr_extra_armor,
+	)
+	cost = 12
+
+/datum/supply_packs/armor/modular/attachments/mimir_environment_protection
+	name = "Jaeger mimir module"
+	contains = list(
+		/obj/item/armor_module/attachable/mimir_environment_protection,
+	)
+	cost = 12
+
+/datum/supply_packs/armor/modular/attachments/mimir_helmet_protection
+	name = "Jaeger helmet mimir module"
+	contains = list(/obj/item/helmet_module/attachable/mimir_environment_protection)
+	cost = 5
+/datum/supply_packs/armor/modular/attachments/generic_helmet_modules
+	name = "Generic Jaeger helmet modules"
+	contains = list(
+		/obj/item/helmet_module/welding,
+		/obj/item/helmet_module/welding,
+		/obj/item/helmet_module/binoculars,
+		/obj/item/helmet_module/binoculars,
+		/obj/item/helmet_module/antenna,
+		/obj/item/helmet_module/antenna,
+	)
+	cost = 5
+/datum/supply_packs/armor/modular/attachments/hlin_bombimmune
+	name = "Jaeger Hlin module"
+	contains = list(/obj/item/armor_module/attachable/hlin_explosive_armor)
+	cost = 12
+
+/*******************************************************************************
+CLOTHING
+*******************************************************************************/
+/datum/supply_packs/clothing
+	group = "Clothing"
+	containertype = /obj/structure/closet/crate
+
+/datum/supply_packs/clothing/combat_pack
+	name = "Combat Backpack"
+	contains = list(/obj/item/storage/backpack/lightpack)
+	cost = 20
+
+/datum/supply_packs/clothing/welding_pack
+	name = "Engineering Welding Pack"
+	contains = list(/obj/item/storage/backpack/marine/engineerpack)
+	cost = 5
+
+/datum/supply_packs/clothing/technician_pack
+	name = "Engineering Technician Pack"
+	contains = list(/obj/item/storage/backpack/marine/tech)
+	cost = 5
+
+/datum/supply_packs/clothing/officer_outfits
+	name = "officer outfits"
+	contains = list(
+		/obj/item/clothing/under/rank/ro_suit,
+		/obj/item/clothing/under/marine/officer/bridge,
+		/obj/item/clothing/under/marine/officer/bridge,
+		/obj/item/clothing/under/marine/officer/exec,
+		/obj/item/clothing/under/marine/officer/ce,
+	)
+	cost = 10
+
+/datum/supply_packs/clothing/marine_outfits
+	name = "marine outfit"
+	contains = list(
+		/obj/item/clothing/under/marine/standard,
+		/obj/item/storage/belt/marine,
+		/obj/item/storage/backpack/marine/standard,
+		/obj/item/clothing/shoes/marine,
+	)
+	cost = 5
+
+/datum/supply_packs/clothing/webbing
+	name = "webbing"
+	contains = list(/obj/item/clothing/tie/storage/webbing)
+	cost = 2
+
+/datum/supply_packs/clothing/brown_vest
+	name = "brown_vest"
+	contains = list(/obj/item/clothing/tie/storage/brown_vest)
+	cost = 2
+
+/datum/supply_packs/clothing/revolver
+	name = "TP-44 holster"
+	contains = list(/obj/item/storage/belt/gun/revolver/standard_revolver)
+	cost = 2
+
+/datum/supply_packs/clothing/pistol
+	name = "TP-14 holster"
+	contains = list(/obj/item/storage/belt/gun/pistol/standard_pistol)
+	cost = 2
+
+/datum/supply_packs/clothing/pouches_general
+	name = "general pouches"
+	contains = list(
+		/obj/item/storage/pouch/general/large,
+		/obj/item/storage/pouch/general/large,
+		/obj/item/storage/pouch/general/large,
+	)
+	cost = 5
+
+/datum/supply_packs/clothing/pouches_weapons
+	name = "weapons pouches"
+	contains = list(
+		/obj/item/storage/pouch/bayonet,
+		/obj/item/storage/pouch/pistol,
+		/obj/item/storage/pouch/explosive,
+	)
+	cost = 5
+
+/datum/supply_packs/clothing/pouches_ammo
+	name = "ammo pouches"
+	contains = list(
+		/obj/item/storage/pouch/magazine/large,
+		/obj/item/storage/pouch/magazine/large,
+		/obj/item/storage/pouch/magazine/pistol/large,
+		/obj/item/storage/pouch/magazine/pistol/large,
+	)
+	cost = 5
+
+/datum/supply_packs/clothing/pouches_medical
+	name = "medical pouches"
+	contains = list(
+		/obj/item/storage/pouch/firstaid,
+		/obj/item/storage/pouch/medical,
+		/obj/item/storage/pouch/syringe,
+		/obj/item/storage/pouch/medkit,
+		/obj/item/storage/pouch/autoinjector,
+	)
+	cost = 5
+
+/datum/supply_packs/clothing/pouches_survival
+	name = "survival pouches"
+	contains = list(
+		/obj/item/storage/pouch/radio,
+		/obj/item/storage/pouch/flare,
+		/obj/item/storage/pouch/survival,
+	)
+	cost = 5
+
+/datum/supply_packs/clothing/pouches_construction
+	name = "construction pouches"
+	contains = list(
+		/obj/item/storage/pouch/document,
+		/obj/item/storage/pouch/electronics,
+		/obj/item/storage/pouch/tools,
+		/obj/item/storage/pouch/construction,
+	)
+	cost = 5
+
+
+/*******************************************************************************
+MEDICAL
+*******************************************************************************/
+/datum/supply_packs/medical
+	group = "Medical"
+	containertype = /obj/structure/closet/crate/medical
+
+/datum/supply_packs/medical/advanced_medical
+	name = "Emergency medical supplies"
+	contains = list(
+		/obj/item/storage/pouch/autoinjector/advanced/full,
+		/obj/item/storage/pouch/autoinjector/advanced/full,
+		/obj/item/storage/pouch/autoinjector/advanced/full,
+		/obj/item/storage/pouch/autoinjector/advanced/full,
+		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus,
+		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline,
+		/obj/item/stack/nanopaste,
+	)
+	cost = 30
+
+/datum/supply_packs/medical/dogtags
+	name = "dogtags crate"
+	contains = list(
+		/obj/item/storage/box/ids/dogtag,
+		/obj/item/storage/box/ids/dogtag,
+		/obj/item/storage/box/ids/dogtag,
+	)
+	cost = 10
+
+/datum/supply_packs/medical/biomass
+	name = "biomass crate"
+	contains = list(
+		/obj/item/reagent_containers/glass/beaker/biomass,
+	)
+	cost = 15
+
+
+/datum/supply_packs/medical/medical
+	name = "Pills and Chemicals"
+	contains = list(
+		/obj/item/storage/box/autoinjectors,
+		/obj/item/storage/box/syringes,
+		/obj/item/reagent_containers/glass/bottle/inaprovaline,
+		/obj/item/reagent_containers/glass/bottle/dylovene,
+		/obj/item/reagent_containers/glass/bottle/bicaridine,
+		/obj/item/reagent_containers/glass/bottle/dexalin,
+		/obj/item/reagent_containers/glass/bottle/spaceacillin,
+		/obj/item/reagent_containers/glass/bottle/kelotane,
+		/obj/item/reagent_containers/glass/bottle/tramadol,
+		/obj/item/storage/pill_bottle/inaprovaline,
+		/obj/item/storage/pill_bottle/dylovene,
+		/obj/item/storage/pill_bottle/bicaridine,
+		/obj/item/storage/pill_bottle/dexalin,
+		/obj/item/storage/pill_bottle/spaceacillin,
+		/obj/item/storage/pill_bottle/kelotane,
+		/obj/item/storage/pill_bottle/tramadol,
+		/obj/item/storage/pill_bottle/quickclot,
+		/obj/item/storage/pill_bottle/peridaxon,
+		/obj/item/storage/box/pillbottles,
+	)
+	cost = 10
+
+/datum/supply_packs/medical/firstaid
+	name = "advanced first aid kit"
+	contains = list(/obj/item/storage/firstaid/adv)
+	cost = 5
+
+/datum/supply_packs/medical/bodybag
+	name = "body bags"
+	notes = "Contains 7 bodybags"
+	contains = list(/obj/item/storage/box/bodybags)
+	cost = 5
+
+/datum/supply_packs/medical/cryobag
+	name = "stasis bag"
+	contains = list(/obj/item/bodybag/cryobag)
+	cost = 5
+
+/datum/supply_packs/medical/surgery
+	name = "surgical equipment"
+	contains = list(
+		/obj/item/storage/surgical_tray,
+		/obj/item/clothing/tie/storage/white_vest,
+		/obj/item/clothing/mask/breath/medical,
+		/obj/item/tank/anesthetic,
+		/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin,
+		/obj/item/reagent_containers/hypospray/autoinjector/sleeptoxin,
+	)
+	cost = 10
+	access = ACCESS_MARINE_MEDBAY
+	containertype = /obj/structure/closet/crate/secure/surgery
+
+/datum/supply_packs/medical/hypospray
+	name = "advanced hypospray"
+	contains = list(/obj/item/reagent_containers/hypospray/advanced)
+	cost = 5
+	containertype = /obj/structure/closet/crate/secure/surgery
+	access = ACCESS_MARINE_MEDBAY
+
+/datum/supply_packs/medical/medvac
+	name = "medvac system"
+	contains = list(
+		/obj/item/roller/medevac,
+		/obj/item/medevac_beacon,
+	)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/surgery
+	access = ACCESS_MARINE_MEDBAY
+
+/datum/supply_packs/medical/lemolime
+	name = "lemoline"
+	notes = "Contains 1 bottle of lemoline with 10 units."
+	contains = list(/obj/item/reagent_containers/glass/bottle/lemoline)
+	cost = 50
+
+/*******************************************************************************
+ENGINEERING
+*******************************************************************************/
+/datum/supply_packs/engineering
+	group = "Engineering"
+	containertype = /obj/structure/closet/crate/supply
+
+/datum/supply_packs/engineering/powerloader
+	name = "RPL-Y Cargo Loader"
+	contains = list(/obj/vehicle/powerloader)
+	cost = 20
+	containertype = null
+
+/datum/supply_packs/engineering/sandbags
+	name = "50 empty sandbags"
+	contains = list(/obj/item/stack/sandbags_empty/full)
+	cost = 10
+
+/datum/supply_packs/engineering/metal50
+	name = "50 metal sheets"
+	contains = list(/obj/item/stack/sheet/metal/large_stack)
+	cost = 20
+
+/datum/supply_packs/engineering/plas50
+	name = "50 plasteel sheets"
+	contains = list(/obj/item/stack/sheet/plasteel/large_stack)
+	cost = 40
+
+/datum/supply_packs/engineering/glass50
+	name = "50 glass sheets"
+	contains = list(/obj/item/stack/sheet/glass/large_stack)
+	cost = 10
+
+/datum/supply_packs/engineering/wood50
+	name = "50 wooden planks"
+	contains = list(/obj/item/stack/sheet/wood/large_stack)
+	cost = 10
+
+/datum/supply_packs/engineering/quikdeploycade
+	name = "quikdeploy barricade (x2)"
+	contains = list(
+		/obj/item/quikdeploy/cade,
+		/obj/item/quikdeploy/cade,
+	)
+	cost = 6
+
+/datum/supply_packs/engineering/pacman
+	name = "P.A.C.M.A.N. Portable Generator"
+	contains = list(/obj/machinery/power/port_gen/pacman)
+	cost = 15
+	containertype = null
+
+/datum/supply_packs/engineering/phoron
+	name = "Phoron Sheets"
+	contains = list(/obj/item/stack/sheet/mineral/phoron/medium_stack)
+	cost = 20
+
+/datum/supply_packs/engineering/electrical
+	name = "electrical maintenance supplies"
+	contains = list(
+		/obj/item/storage/toolbox/electrical,
+		/obj/item/clothing/gloves/yellow,
+		/obj/item/cell,
+		/obj/item/cell/high,
+	)
+	cost = 5
+
+/datum/supply_packs/engineering/mechanical
+	name = "mechanical maintenance crate"
+	contains = list(
+		/obj/item/storage/belt/utility/full,
+		/obj/item/storage/belt/utility/full,
+		/obj/item/storage/belt/utility/full,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/head/welding,
+		/obj/item/clothing/head/welding,
+		/obj/item/clothing/head/hardhat,
+	)
+	cost = 10
+
+/datum/supply_packs/engineering/fueltank
+	name = "fuel tank"
+	contains = list(/obj/structure/reagent_dispensers/fueltank)
+	cost = 10
+	containertype = null
+
+/datum/supply_packs/engineering/watertank
+	name = "Water Tank"
+	contains = list(/obj/structure/reagent_dispensers)
+	cost = 5
+	containertype = null
+
+/datum/supply_packs/engineering/inflatable
+	name = "inflatable barriers"
+	notes = "Contains 3 doors and 4 walls"
+	contains = list(/obj/item/storage/briefcase/inflatable)
+	cost = 5
+
+/datum/supply_packs/engineering/lightbulbs
+	name = "replacement lights"
+	notes = "Contains 14 tubes, 7 bulbs"
+	contains = list(/obj/item/storage/box/lights/mixed)
+	cost = 5
+
+/datum/supply_packs/engineering/foam_grenade
+	name = "Foam Grenade"
+	contains = list(/obj/item/explosive/grenade/chem_grenade/metalfoam)
+	cost = 3
+
+/*******************************************************************************
+SUPPLIES
+*******************************************************************************/
+/datum/supply_packs/supplies
+	group = "Supplies"
+	containertype = /obj/structure/closet/crate/supply
+
+/datum/supply_packs/supplies/mre
+	name = "TGMC MRE crate"
+	notes = "Contains 4 MREs"
+	contains = list(/obj/item/storage/box/MRE)
+	cost = 1
+
+/datum/supply_packs/supplies/crayons
+	name = "PFC Jim Special Crayon Pack"
+	contains = list(/obj/item/storage/fancy/crayons)
+	cost = 4
+
+/datum/supply_packs/supplies/janitor
+	name = "assorted janitorial supplies"
+	contains = list(
+		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/tool/mop,
+		/obj/item/tool/wet_sign,
+		/obj/item/tool/wet_sign,
+		/obj/item/tool/wet_sign,
+		/obj/item/storage/bag/trash,
+		/obj/item/reagent_containers/spray/cleaner,
+		/obj/item/reagent_containers/glass/rag,
+		/obj/item/explosive/grenade/chem_grenade/cleaner,
+		/obj/item/explosive/grenade/chem_grenade/cleaner,
+		/obj/item/explosive/grenade/chem_grenade/cleaner,
+		/obj/structure/mopbucket,
+		/obj/item/paper/janitor,
+	)
+	cost = 5
+
+/*******************************************************************************
+Imports
+*******************************************************************************/
+/datum/supply_packs/imports
+	group = "Imports"
+	containertype = /obj/structure/closet/crate/weapon
+
+/datum/supply_packs/imports/specscoutmbx
+	name = "MBX-900 Lever Action Shotgun"
+	contains = list(/obj/item/weapon/gun/shotgun/pump/lever/mbx900)
+	cost = 15
+
+/datum/supply_packs/imports/mbx900
+	name = "MBX-900 Sabot Shells"
+	contains = list(/obj/item/ammo_magazine/shotgun/mbx900)
+	cost = 5
+
+/datum/supply_packs/imports/mbx900/buckshot
+	name = "MBX-900 Buckshot Shells"
+	contains = list(/obj/item/ammo_magazine/shotgun/mbx900/buckshot)
+	cost = 5
+
+/datum/supply_packs/imports/mbx900/tracker
+	name = "MBX-900 Tracker Shells"
+	contains = list(/obj/item/ammo_magazine/shotgun/mbx900/tracking)
+	cost = 5
+
+/datum/supply_packs/imports/m41a
+	name = "M41A Pulse Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/m41a)
+	cost = 15
+
+/datum/supply_packs/imports/m41a/ammo
+	name = "M41A Pulse Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/m41a)
+	cost = 5
+
+/datum/supply_packs/imports/m412
+	name = "M412 Pulse Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/m412)
+	cost = 15
+
+/datum/supply_packs/imports/m41a2/ammo
+	name = "M412 Pulse Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle)
+	cost = 5
+
+/datum/supply_packs/imports/m412l1
+	name = "M412L1 Heavy Pulse Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/m412l1_hpr)
+	cost = 15
+
+/datum/supply_packs/imports/m412l1/ammo
+	name = "M412L1 Heavy Pulse Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/m412l1_hpr)
+	cost = 5
+
+/datum/supply_packs/imports/type71	//Moff gun
+	name = "Type 71 Pulse Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/type71)
+	cost = 15
+
+/datum/supply_packs/imports/type71/ammo
+	name = "Type 71 Pulse Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/type71)
+	cost = 5
+
+/datum/supply_packs/imports/mp7
+	name = "MP7 SMG"
+	contains = list(/obj/item/weapon/gun/smg/mp7)
+	cost = 15
+
+/datum/supply_packs/imports/mp7/ammo
+	name = "MP7 SMG Ammo"
+	contains = list(/obj/item/ammo_magazine/smg/mp7)
+	cost = 5
+
+/datum/supply_packs/imports/m25
+	name = "MR-25 SMG"
+	contains = list(/obj/item/weapon/gun/smg/m25)
+	cost = 15
+
+/datum/supply_packs/imports/m25/ammo
+	name = "MR-25 SMG Ammo"
+	contains = list(/obj/item/ammo_magazine/smg/m25)
+	cost = 5
+
+/datum/supply_packs/imports/skorpion
+	name = "Skorpion SMG"
+	contains = list(/obj/item/weapon/gun/smg/skorpion)
+	cost = 15
+
+/datum/supply_packs/imports/skorpion/ammo
+	name = "Skorpion SMG Ammo"
+	contains = list(/obj/item/ammo_magazine/smg/skorpion)
+	cost = 5
+
+/datum/supply_packs/imports/uzi
+	name = "GAL-9 SMG"
+	contains = list(/obj/item/weapon/gun/smg/uzi)
+	cost = 10
+
+/datum/supply_packs/imports/uzi/ammo
+	name = "GAL-9 SMG Ammo"
+	contains = list(/obj/item/ammo_magazine/smg/uzi)
+	cost = 3
+
+/datum/supply_packs/imports/ppsh
+	name = "PPSH SMG"
+	contains = list(/obj/item/weapon/gun/smg/ppsh)
+	cost = 15
+
+/datum/supply_packs/imports/ppsh/ammo
+	name = "PPSH SMG Ammo Drum"
+	contains = list(/obj/item/ammo_magazine/smg/ppsh/extended)
+	cost = 5
+
+/datum/supply_packs/imports/sawnoff
+	name = "Sawn Off Shotgun"
+	contains = list(/obj/item/weapon/gun/shotgun/double/sawn)
+	cost = 15
+
+/datum/supply_packs/imports/leveraction
+	name = "Lever Action Rifle"
+	contains = list(/obj/item/weapon/gun/shotgun/pump/lever)
+	cost = 15
+
+/datum/supply_packs/imports/leveraction/ammo
+	name = "Lever Action Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/magnum)
+	cost = 5
+
+/datum/supply_packs/imports/mosin
+	name = "Mosin Nagant Sniper"
+	contains = list(/obj/item/weapon/gun/shotgun/pump/bolt)
+	cost = 15
+
+/datum/supply_packs/imports/mosin/ammo
+	name = "Mosin Nagant Sniper Ammo (x2)"
+	contains = list(
+		/obj/item/ammo_magazine/rifle/bolt,
+		/obj/item/ammo_magazine/rifle/bolt,
+	)
+	cost = 5
+
+/datum/supply_packs/imports/dragunov
+	name = "SVD Dragunov Sniper"
+	contains = list(/obj/item/weapon/gun/rifle/sniper/svd)
+	cost = 15
+
+/datum/supply_packs/imports/dragunov/ammo
+	name = "SVD Dragunov Sniper Ammo"
+	contains = list(/obj/item/ammo_magazine/sniper/svd)
+	cost = 5
+
+/datum/supply_packs/imports/ak47
+	name = "AK-47 Assault Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/ak47)
+	cost = 15
+
+/datum/supply_packs/imports/ak47/ammo
+	name = "AK-47 Assault Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/ak47)
+	cost = 5
+
+/datum/supply_packs/imports/ak47u
+	name = "AK-47U Battle Carbine"
+	contains = list(/obj/item/weapon/gun/rifle/ak47/carbine)
+	cost = 15
+
+/datum/supply_packs/imports/ak47u/ammo
+	name = "AK-47U Battle Carbine Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/ak47)
+	cost = 5
+
+/datum/supply_packs/imports/m16	//Vietnam time
+	name = "FN M16A Assault Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/m16)
+	cost = 15
+
+/datum/supply_packs/imports/m16/ammo
+	name = "FN M16A Assault Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/m16)
+	cost = 5
+
+/datum/supply_packs/imports/famas //bread joke here
+	name = "FAMAS Assault Rifle"
+	contains = list(/obj/item/weapon/gun/rifle/famas)
+	cost = 15
+
+/datum/supply_packs/imports/m16/ammo
+	name = "FAMAS Assault Rifle Ammo"
+	contains = list(/obj/item/ammo_magazine/rifle/famas)
+	cost = 5
+
+/datum/supply_packs/imports/rev357
+	name = "Smith and Wesson 357 Revolver"
+	contains = list(/obj/item/weapon/gun/revolver/small)
+	cost = 7
+
+/datum/supply_packs/imports/rev357/ammo
+	name = "Smith and Wesson 357 Revolver Ammo"
+	contains = list(/obj/item/ammo_magazine/revolver/small)
+	cost = 3
+
+/datum/supply_packs/imports/rev44
+	name = "M-44 SAA Revolver"
+	contains = list(/obj/item/weapon/gun/revolver/m44)
+	cost = 7
+
+/datum/supply_packs/imports/rev357/ammo
+	name = "M-44 SAA Revolver Ammo"
+	contains = list(/obj/item/ammo_magazine/revolver)
+	cost = 3
+
+/datum/supply_packs/imports/beretta92fs
+	name = "Beretta 92FS Handgun"
+	contains = list(/obj/item/weapon/gun/pistol/b92fs)
+	cost = 7
+
+/datum/supply_packs/imports/beretta92fs/ammo
+	name = "Beretta 92FS Handgun Ammo"
+	contains = list(/obj/item/ammo_magazine/pistol/b92fs)
+	cost = 3
+
+/datum/supply_packs/imports/beretta93r
+	name = "Beretta 93R Handgun"
+	contains = list(/obj/item/weapon/gun/pistol/b92fs/raffica)
+	cost = 7
+
+/datum/supply_packs/imports/beretta93r/ammo
+	name = "Beretta 93R Handgun Ammo"
+	contains = list(/obj/item/ammo_magazine/pistol/b93r)
+	cost = 3
+
+/datum/supply_packs/imports/deagle
+	name = "Desert Eagle Handgun"
+	contains = list(/obj/item/weapon/gun/pistol/heavy)
+	cost = 7
+
+/datum/supply_packs/imports/deagle/ammo
+	name = "Desert Eagle Handgun Ammo"
+	contains = list(/obj/item/ammo_magazine/pistol/heavy)
+	cost = 3
+
+/datum/supply_packs/imports/vp78
+	name = "VP78 Handgun"
+	contains = list(/obj/item/weapon/gun/pistol/vp78)
+	cost = 7
+
+/datum/supply_packs/imports/vp78/ammo
+	name = "VP78 Handgun Ammo"
+	contains = list(/obj/item/ammo_magazine/pistol/vp78)
+	cost = 3
+
+/datum/supply_packs/imports/highpower
+	name = "Highpower Automag"
+	contains = list(/obj/item/weapon/gun/pistol/highpower)
+	cost = 7
+
+/datum/supply_packs/imports/highpower/ammo
+	name = "Highpower Automag Ammo"
+	contains = list(/obj/item/ammo_magazine/pistol/highpower)
+	cost = 3
+
+/datum/supply_packs/imports/strawhat
+	name = "Straw hat"
+	contains = list(/obj/item/clothing/head/strawhat)
+	cost = 1


### PR DESCRIPTION
## About The Pull Request
Adds Two MBX-900s to marine cargo vendor along with some ammo.
Changes MBX-900 to an import gun with 15 point buy, 5 point buy for ammo.
## Why It's Good For The Game
Makes MBX a tad bit more useful and not a waste of 80 points for a mediocre gun.

## Changelog
:cl:
add: Add: Added MBX-900 to marine cargo weapon vendor. Added 10 boxes of .410 buckshot and .410 sabot each.
balance: Moved MBX-900 to Imports and reduced buy cost to 15 points, from 80.
/:cl:
