### PR TITLE
NO_DECAP Field Commander Berets

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -76,6 +76,7 @@
 	icon_state = "beretfc"
 	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 50, "acid" = 50)
 	flags_item_map_variant = NONE
+	flags_armor_features = ARMOR_NO_DECAP
 
 
 /obj/item/clothing/head/tgmccap


### PR DESCRIPTION

## About The Pull Request
Adds a ARMOR_NO_DECAP flag to the FC beret, 'nuff said.

## Why It's Good For The Game
Maintains consistency as other high armor head wear (Jaegar, M10, ERT berets) feature the NO_DECAP flag and I find it odd that the FC beret doesn't contain this flag. Also, because for fashion.

## Changelog
:cl:
tweak: People wearing FC berets can no longer be decapitated
/:cl: